### PR TITLE
Improve typescript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,4 +10,11 @@ declare module 'mongoose' {
       class Long extends SchemaType {}
     }
   }
+  
+  namespace Types {
+    class Long extends SchemaType {
+      static fromString: (long: string) => Long;
+      static fromString: (long: number) => Long;
+    }
+  }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ declare module 'mongoose' {
   namespace Types {
     class Long extends SchemaType {
       static fromString: (long: string) => Long;
-      static fromString: (long: number) => Long;
+      static fromNumber: (long: number) => Long;
     }
   }
 }


### PR DESCRIPTION
Importing Long constructor from mongoose.Types.Long or using fromString or fromNumber methods in typescript result in errors. So I added types for them.