### PR TITLE
Update url for MongoDB Docs Long Class 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ part.save()
 npm install mongoose-long
 ```
 
-See [node-mongodb-native](http://mongodb.github.com/node-mongodb-native/api-bson-generated/long.html) docs on all the `Long` methods available.
+See [node-mongodb-native](https://mongodb.github.io/node-mongodb-native/4.2/classes/Long.html) docs on all the `Long` methods available.
 
 [LICENSE](https://github.com/aheckmann/mongoose-long/blob/master/LICENSE)
 


### PR DESCRIPTION
### Description:
- update the readme link to MongoDB Long docs
- Current link is 404 - http://mongodb.github.com/node-mongodb-native/api-bson-generated/long.html
- Change to be - https://mongodb.github.io/node-mongodb-native/4.2/classes/Long.html