### PR TITLE
Support for Mongoose 7.x

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,8 +104,20 @@ module.exports = exports = function NumberLong (mongoose) {
    * @param {*} [value]
    */
 
-  Long.prototype.castForQuery = function ($conditional, value) {
+  Long.prototype.castForQuery = function ($conditional, value, context) {
     var handler;
+    if (3 === arguments.length) {
+      // mongoose 7
+      if ($conditional != null) {
+        handler = this.$conditionalHandlers[$conditional];
+        if (!handler) {
+            throw new Error("Can't use " + $conditional + " with Long.");
+        }
+        return handler.call(this, value);
+      } else {
+        return this.cast(value);
+      }
+    }
     if (2 === arguments.length) {
       handler = this.$conditionalHandlers[$conditional];
       if (!handler) {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   "license": "MIT",
   "devDependencies": {
     "mocha": "*",
-    "mongoose": "6.x"
+    "mongoose": "7.x"
   },
   "peerDependencies": {
-    "mongoose": "4.x || 5.x || 6.x"
+    "mongoose": "4.x || 5.x || 6.x || 7.x"
   }
 }


### PR DESCRIPTION
castForQuery updated for 3 arguments
Mocha tests modified to remove callbacks and replace with Promise usage.